### PR TITLE
instantiate docs and initial attempt at glossary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs/build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,60 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Survey Builder'
+copyright = '2020, Statistical Perceptions Team'
+author = 'Statistical Perceptions Team'
+
+# The full version, including alpha/beta/rc tags
+release = '.1'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ['recommonmark']
+
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}
+
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ release = '.1'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['recommonmark']
+# extensions = ['recommonmark']
 
 source_suffix = {
     '.rst': 'restructuredtext',

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -7,7 +7,7 @@ Key terms used throughout the project
   :sorted:
 
   study
-    a fully configured experiment for a participant that consists of FIXME
+    a fully configured experiment for a participant that consists of qualtrics surveys and an experiment on this platform including a specific cohort of subjects
 
   instance
     a deployment of the statistical perceptions platform consisting contained in

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -14,9 +14,7 @@ Key terms used throughout the project
     one Heroku app. An instance of the app consists of one set of databases.
 
   experiment
-    a template for studies. a given experiment can be run many times with
-    different settings for different studies. an experiment consists of a set
-    of items of a given type but may have different values of parameters
+    a group of items with all parameters set. 
 
   app
     a website, on which experiments can be either designed and saved, or on which experiments can be run by survey respondents

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -19,7 +19,7 @@ Key terms used throughout the project
     of items of a given type but may have different values of parameters
 
   app
-    FIXME as in app1 and app2
+    a website, on which experiments can be either designed and saved, or on which experiments can be run by survey respondents
 
   survey
     a group of items

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -15,7 +15,8 @@ Key terms used throughout the project
 
   experiment
     a template for studies. a given experiment can be run many times with
-    different settings for different studies.
+    different settings for different studies. an experiment consists of a set
+    of items of a given type but may have different values of parameters
 
   app
     FIXME as in app1 and app2
@@ -24,4 +25,4 @@ Key terms used throughout the project
     a group of items
 
   item
-    an individual widget
+    an individual interactive component to be displayed to the participant

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -1,0 +1,24 @@
+.. glossary::
+
+  study
+    a fully configured experiment for a participant that consists of FIXME
+
+  researcher
+    the person who runs individual studies
+
+  instance
+    a deployment of the statistical perceptions platform consisting contained in
+    one Heroku app. An instance of the app consists of one set of databases.
+
+  experiment
+    a template for studies. a given experiment can be run many times with
+    different settings for different studies.
+
+  app
+    FIXME as in app1 and app2
+
+  survey
+    a group of items
+
+  item
+    an individual widget

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -9,9 +9,6 @@ Key terms used throughout the project
   study
     a fully configured experiment for a participant that consists of FIXME
 
-  researcher
-    the person who runs individual studies
-
   instance
     a deployment of the statistical perceptions platform consisting contained in
     one Heroku app. An instance of the app consists of one set of databases.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -1,4 +1,10 @@
+Glossary
+--------
+
+Key terms used throughout the project
+
 .. glossary::
+  :sorted:
 
   study
     a fully configured experiment for a participant that consists of FIXME

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,17 @@ Welcome to Survey Builder's documentation!
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
+   
+   glossary.rst
+   roles.rst
+   technical-overview.rst
+
+
+
+Here we describe the basic use case of setting up and running experiments with our
+tool.
+
+
 
 
 
@@ -18,3 +29,4 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+* :ref:`glossary`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+.. Survey Builder documentation master file, created by
+   sphinx-quickstart on Fri Jun 26 18:05:43 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Survey Builder's documentation!
+==========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/roles.rst
+++ b/docs/source/roles.rst
@@ -21,3 +21,8 @@ to the system
 
   developer
     builds, maintains and administers systems; manages app deployment
+
+  PI
+    lead researchers of either discipline; faculty; need access to all, for
+    longevity reasons, can be trusted to have access to things they do not
+    understand

--- a/docs/source/roles.rst
+++ b/docs/source/roles.rst
@@ -1,0 +1,23 @@
+Roles
+------
+
+An individual person may have multiple roles in the project, but these roles
+define what is expected in terms of the documentation nad the level of access
+to the system
+
+.. glossary::
+  :sorted:
+
+  behavioral scientist
+  psychologist
+  scientist
+    Studies people. runs term:`studies`, requires access to use survey builder and download data, does
+    not write code or manage backend
+
+  ML researcher
+    Studies algorithms, can write code, but may not be well versed in all of the
+    components of the app; understands algorithms well, but less about
+    infrastructure
+
+  developer
+    builds, maintains and administers systems; manages app deployment

--- a/docs/source/technical-overview.rst
+++ b/docs/source/technical-overview.rst
@@ -8,7 +8,7 @@ exist, an :term:`instance` of the platform should be deployed.
 
 
 A :term:`scientist` who wants to run a :term:`study` will create an account on
- that instance and log in to their account.
+ that :term:`instance` and log in to their account.
 The scientist will choose what type of experiment for the given study and then
 set the parameters that the experiment requires as required for the specific
 hypotheses of the current study.
@@ -25,31 +25,48 @@ retrieved json to pass it to the frontend.
 
 When the study is configured ....(qualtrics stuff)
 
-The participant will interact with a separate app, based on the custom URL that
-directs them to the right configuration for the app. THey will enter their unique
+The participant will interact with FIXME:app2, based on the custom URL that
+directs them to the right configuration for the app. They will enter their unique
 identifier and then be presented with the interactive questions as needed.
 
 
-Question Types
+Item Types
 ----------------
 
 **Normal Curves**
-control: slider that controls how much two curves overlap
+for questions about groupwise comparisons
+control: slider that controls how much two curves overlap, next button
 parameters: variances, labeling (group names, text for axis of comparison)
-records: amount of overlapm(or two locations, to compute later)
+records: amount of overlap(or two locations, to compute later)
 
 **Fairness metric tradeoff**
+for tradeoffs between competing metrics
 control: slider to move decision boundary according to optimizing for one or
-another metric
+another metric, next button
 parameters: ROC?/ tbd, labeling
 records: preferred location of tradeoff
 
 
-Survey formats
+**Static Information**
+for added information between prompts
+control: next button
+paramters: text and images or link to video to embed
+records: nothing
+
+
+Experiment formats
 ---------------
 
+- 1 interactive item
+- interactive item, static, interactive
 
-FIXME
+
+Study Formats
+--------------------
+
+- qualtrics surveys + single interactive experiment for all subjects
+- qualtrics surveys + 2 interactive experiments to which subjects are randomzied
+
 
 
 Instance Contents

--- a/docs/source/technical-overview.rst
+++ b/docs/source/technical-overview.rst
@@ -4,10 +4,10 @@ Technical Overview
 .. note: some of this is untrue as of yet, but what will, for planning purposes
 
 When development is complete and all components needed for a set of experiments
-exist, an instance of the apps should be deployed.
+exist, an :term:`instance` of the apps should be deployed.
 
 
-A researcher wants to run a study will create an account on that instance
+A :term:`scientist` who wants to run a :term:`study` will create an account on that instance
 and log in to their account.
 The scientist will choose what type of experiment for the given study and then
 set the parameters that the experiment requires as required for the specific
@@ -16,15 +16,15 @@ hypotheses of the current study.
 Instance Contents
 -----------------
 
-Within a given instance, multiple researchers may run multiple studies of
+Within a given instance, multiple scientists may run multiple studies of
 varying or repeating experiment types. The experiment types available within an
-instance cannot be changed or extended. An instance contains a single database 
+instance cannot be changed or extended. An instance contains a single database
 with multiple collections.
 
 Access
 -------
 
-Across two instances, a researcher would need to maintain separate logins. After
-logging in, a researcher can view all of the studies that they have configured.
+Across two instances, a scientist would need to maintain separate logins. After
+logging in, a scientist can view all of the studies that they have configured.
 A research admin or PI can login to an instance and see all of the data from all
-studies on an instance as the individual researchers can.
+studies on an instance as the individual scientist can.

--- a/docs/source/technical-overview.rst
+++ b/docs/source/technical-overview.rst
@@ -3,15 +3,54 @@ Technical Overview
 
 .. note: some of this is untrue as of yet, but what will, for planning purposes
 
-When development is complete and all components needed for a set of experiments
-exist, an :term:`instance` of the apps should be deployed.
+When development is complete and all components needed for a set of studies
+exist, an :term:`instance` of the platform should be deployed.
 
 
-A :term:`scientist` who wants to run a :term:`study` will create an account on that instance
-and log in to their account.
+A :term:`scientist` who wants to run a :term:`study` will create an account on
+ that instance and log in to their account.
 The scientist will choose what type of experiment for the given study and then
 set the parameters that the experiment requires as required for the specific
 hypotheses of the current study.
+
+The scientist will interact with a configuration app that has a react frontend
+and a flask backend. The flask part will import a package that defines the types
+of experiments and integrate with the MongoDB.
+
+The Experiment package will implement a class for each type of experiment that
+has methods needed to collect necessary scientist selected parameters,
+compute the needed values to generate the display for the participant, and store
+those to the MongoDB. Each class will also contain methods to read from the
+retrieved json to pass it to the frontend.
+
+When the study is configured ....(qualtrics stuff)
+
+The participant will interact with a separate app, based on the custom URL that
+directs them to the right configuration for the app. THey will enter their unique
+identifier and then be presented with the interactive questions as needed.
+
+
+Question Types
+----------------
+
+**Normal Curves**
+control: slider that controls how much two curves overlap
+parameters: variances, labeling (group names, text for axis of comparison)
+records: amount of overlapm(or two locations, to compute later)
+
+**Fairness metric tradeoff**
+control: slider to move decision boundary according to optimizing for one or
+another metric
+parameters: ROC?/ tbd, labeling
+records: preferred location of tradeoff
+
+
+Survey formats
+---------------
+
+
+FIXME
+
 
 Instance Contents
 -----------------

--- a/docs/source/technical-overview.rst
+++ b/docs/source/technical-overview.rst
@@ -1,0 +1,30 @@
+Technical Overview
+===================
+
+.. note: some of this is untrue as of yet, but what will, for planning purposes
+
+When development is complete and all components needed for a set of experiments
+exist, an instance of the apps should be deployed.
+
+
+A researcher wants to run a study will create an account on that instance
+and log in to their account.
+The scientist will choose what type of experiment for the given study and then
+set the parameters that the experiment requires as required for the specific
+hypotheses of the current study.
+
+Instance Contents
+-----------------
+
+Within a given instance, multiple researchers may run multiple studies of
+varying or repeating experiment types. The experiment types available within an
+instance cannot be changed or extended. An instance contains a single database 
+with multiple collections.
+
+Access
+-------
+
+Across two instances, a researcher would need to maintain separate logins. After
+logging in, a researcher can view all of the studies that they have configured.
+A research admin or PI can login to an instance and see all of the data from all
+studies on an instance as the individual researchers can.

--- a/docs/source/technical-overview.rst
+++ b/docs/source/technical-overview.rst
@@ -47,8 +47,8 @@ parameters: ROC?/ tbd, labeling
 records: preferred location of tradeoff
 
 
-**Static Information**
-for added information between prompts
+**Information**
+for added information between prompts, noninteractive, may depend on previous responses
 control: next button
 paramters: text and images or link to video to embed
 records: nothing


### PR DESCRIPTION
We need to get researcher input on how much variation and structure they want to repeat to finalize, but this is a starting point. Look mostly at `docs/source/glossary.rst` and `docs/source/technical-overview.rst`